### PR TITLE
fix: set universe_domain when initializing credentials

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   Max: 30
 
+Metrics/ModuleLength:
+  Max: 125
+
 Metrics/ParameterLists:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+0.6.0
+----------
+
+- Support setting the universe domain (defaults to googleapis.com) so gRPC google-cloud clients don't raise Gapic::UniverseDomainMismatch.
+- drop `addressable` as a transitive dependency, replace with stdlib `uri`.
+- drop `faraday` as a transitive dependency, replace with stdlib `net-http`.
+- Bump minimum supported `googleauth` version which allows removing the identity credentials refresh patch (which has been fixed upstream).
+- Clamp supported `signet` to `< 1` instead (no API regressions expected).
+
 0.5.0
 ----------
 

--- a/lib/google/auth/extras.rb
+++ b/lib/google/auth/extras.rb
@@ -58,6 +58,10 @@ module Google
       #   The OAuth 2 scopes to request. Can either be formatted as a comma seperated string or array.
       #   Only supported when not using a target_audience.
       #
+      # @param universe_domain [String]
+      #   The universe domain of the credential, reported to gRPC google-cloud clients so they
+      #   don't raise Gapic::UniverseDomainMismatch. Defaults to googleapis.com.
+      #
       # @return [Google::Auth::Extras::ImpersonatedCredential]
       #
       # @see https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
@@ -73,7 +77,8 @@ module Google
         lifetime: nil,
         quota_project_id: nil,
         scope: nil,
-        target_audience: nil
+        target_audience: nil,
+        universe_domain: 'googleapis.com'
       )
         ImpersonatedCredential.new(
           base_credentials: base_credentials,
@@ -84,6 +89,7 @@ module Google
           quota_project_id: quota_project_id,
           scope: scope,
           target_audience: target_audience,
+          universe_domain: universe_domain,
         )
       end
 
@@ -120,6 +126,10 @@ module Google
       #   The OAuth 2 scopes to request. Can either be formatted as a comma seperated string or array.
       #   Only supported when not using a target_audience.
       #
+      # @param universe_domain [String]
+      #   The universe domain of the credential, reported to gRPC google-cloud clients so they
+      #   don't raise Gapic::UniverseDomainMismatch. Defaults to googleapis.com.
+      #
       # @return [Google::Auth::Credential<Google::Auth::Extras::ImpersonatedCredential>]
       #
       # @see https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
@@ -135,7 +145,8 @@ module Google
         lifetime: nil,
         quota_project_id: nil,
         scope: nil,
-        target_audience: nil
+        target_audience: nil,
+        universe_domain: 'googleapis.com'
       )
         wrap_authorization(
           impersonated_authorization(
@@ -147,6 +158,7 @@ module Google
             quota_project_id: quota_project_id,
             scope: scope,
             target_audience: target_audience,
+            universe_domain: universe_domain,
           ),
         )
       end
@@ -181,6 +193,10 @@ module Google
       # @param target_audience [String]
       #   The audience for the token, such as the API or account that this token grants access to.
       #
+      # @param universe_domain [String]
+      #   The universe domain of the credential, reported to gRPC google-cloud clients so they
+      #   don't raise Gapic::UniverseDomainMismatch. Defaults to googleapis.com.
+      #
       # @return [Google::Auth::Extras::ServiceAccountJWTCredential]
       #
       # @see https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signJwt
@@ -193,7 +209,8 @@ module Google
         delegate_email_addresses: nil,
         issuer: nil,
         lifetime: 3600,
-        subject: nil
+        subject: nil,
+        universe_domain: 'googleapis.com'
       )
         ServiceAccountJWTCredential.new(
           base_credentials: base_credentials,
@@ -203,6 +220,7 @@ module Google
           lifetime: lifetime,
           subject: subject,
           target_audience: target_audience,
+          universe_domain: universe_domain,
         )
       end
 
@@ -234,6 +252,10 @@ module Google
       # @param target_audience [String]
       #   The audience for the token, such as the API or account that this token grants access to.
       #
+      # @param universe_domain [String]
+      #   The universe domain of the credential, reported to gRPC google-cloud clients so they
+      #   don't raise Gapic::UniverseDomainMismatch. Defaults to googleapis.com.
+      #
       # @return [Google::Auth::Extras::ServiceAccountJWTCredential]
       #
       # @see https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signJwt
@@ -246,7 +268,8 @@ module Google
         delegate_email_addresses: nil,
         issuer: nil,
         lifetime: 3600,
-        subject: nil
+        subject: nil,
+        universe_domain: 'googleapis.com'
       )
         wrap_authorization(
           service_account_jwt_authorization(
@@ -257,6 +280,7 @@ module Google
             lifetime: lifetime,
             subject: subject,
             target_audience: target_audience,
+            universe_domain: universe_domain,
           ),
         )
       end
@@ -271,11 +295,14 @@ module Google
       #   The project ID used for quota and billing. This project may be different from
       #   the project used to create the credentials.
       #
+      # @param universe_domain [String]
+      #   The universe domain of the credential, reported to gRPC google-cloud clients so they
+      #   don't raise Gapic::UniverseDomainMismatch. Defaults to googleapis.com.
       #
       # @return [Google::Auth::Extras::StaticCredential]
       #
-      def static_authorization(token, quota_project_id: nil)
-        StaticCredential.new(access_token: token, quota_project_id: quota_project_id)
+      def static_authorization(token, quota_project_id: nil, universe_domain: 'googleapis.com')
+        StaticCredential.new(access_token: token, quota_project_id: quota_project_id, universe_domain: universe_domain)
       end
 
       # A credential using a static access token. For usage with the newer
@@ -288,17 +315,25 @@ module Google
       #   The project ID used for quota and billing. This project may be different from
       #   the project used to create the credentials.
       #
+      # @param universe_domain [String]
+      #   The universe domain of the credential, reported to gRPC google-cloud clients so they
+      #   don't raise Gapic::UniverseDomainMismatch. Defaults to googleapis.com.
+      #
       # @return [Google::Auth::Credential<Google::Auth::Extras::StaticCredential>]
       #
-      def static_credential(token, quota_project_id: nil)
-        wrap_authorization(static_authorization(token, quota_project_id: quota_project_id))
+      def static_credential(token, quota_project_id: nil, universe_domain: 'googleapis.com')
+        wrap_authorization(
+          static_authorization(token, quota_project_id: quota_project_id, universe_domain: universe_domain),
+        )
       end
 
       # Take an authorization and turn it into a credential, primarily used
       # for setting up both the old and new style SDKs.
       #
       # @param client [Signet::OAuth2::Client]
-      #   Authorization credential to wrap.
+      #   Authorization credential to wrap. The universe domain reported to gRPC google-cloud
+      #   clients (so they don't raise Gapic::UniverseDomainMismatch) is taken from the client
+      #   as-is; set it on the client before wrapping if needed.
       #
       # @return [Google::Auth::Credential]
       #

--- a/lib/google/auth/extras/impersonated_credential.rb
+++ b/lib/google/auth/extras/impersonated_credential.rb
@@ -47,6 +47,10 @@ module Google
         # @param target_audience [String]
         #   The audience for the token, such as the API or account that this token grants access to.
         #
+        # @param universe_domain [String]
+        #   The universe domain of the credential, reported to gRPC google-cloud clients so they
+        #   don't raise Gapic::UniverseDomainMismatch. Defaults to googleapis.com.
+        #
         # @see https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
         # @see https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateIdToken
         # @see https://cloud.google.com/iam/docs/create-short-lived-credentials-delegated#sa-credentials-permissions
@@ -60,9 +64,15 @@ module Google
           lifetime: nil,
           quota_project_id: nil,
           scope: nil,
-          target_audience: nil
+          target_audience: nil,
+          universe_domain: 'googleapis.com'
         )
-          super(client_id: target_audience, scope: scope, target_audience: target_audience)
+          super(
+            client_id: target_audience,
+            scope: scope,
+            target_audience: target_audience,
+            universe_domain: base_credentials&.universe_domain || universe_domain,
+          )
 
           if self.target_audience.nil? || self.target_audience.empty?
             raise(ArgumentError, 'Must provide scope or target_audience') if self.scope.nil? || self.scope.empty?

--- a/lib/google/auth/extras/service_account_jwt_credential.rb
+++ b/lib/google/auth/extras/service_account_jwt_credential.rb
@@ -32,6 +32,10 @@ module Google
         # @param target_audience [String]
         #   The audience for the token, such as the API or account that this token grants access to.
         #
+        # @param universe_domain [String]
+        #   The universe domain of the credential, reported to gRPC google-cloud clients so they
+        #   don't raise Gapic::UniverseDomainMismatch. Defaults to googleapis.com.
+        #
         # @see https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signJwt
         # @see https://cloud.google.com/iam/docs/create-short-lived-credentials-delegated#sa-credentials-permissions
         #
@@ -42,9 +46,14 @@ module Google
           delegate_email_addresses: nil,
           issuer: nil,
           lifetime: 3600,
-          subject: nil
+          subject: nil,
+          universe_domain: 'googleapis.com'
         )
-          super(client_id: target_audience, target_audience: target_audience)
+          super(
+            client_id: target_audience,
+            target_audience: target_audience,
+            universe_domain: base_credentials&.universe_domain || universe_domain,
+          )
 
           @iam_credentials_service = Google::Apis::IamcredentialsV1::IAMCredentialsService.new.tap do |ics|
             ics.authorization = base_credentials if base_credentials

--- a/lib/google/auth/extras/static_credential.rb
+++ b/lib/google/auth/extras/static_credential.rb
@@ -18,11 +18,16 @@ module Google
         #   The project ID used for quota and billing. This project may be different from
         #   the project used to create the credentials.
         #
-        def initialize(access_token:, quota_project_id: nil)
+        # @param universe_domain [String]
+        #   The universe domain of the credential, reported to gRPC google-cloud clients so they
+        #   don't raise Gapic::UniverseDomainMismatch. Defaults to googleapis.com.
+        #
+        def initialize(access_token:, quota_project_id: nil, universe_domain: 'googleapis.com')
           super(
             access_token: access_token,
             expires_at: TokenInfo.lookup_access_token(access_token).fetch('exp'),
             issued_at: nil,
+            universe_domain: universe_domain,
           )
 
           @quota_project_id = quota_project_id

--- a/lib/google/auth/extras/version.rb
+++ b/lib/google/auth/extras/version.rb
@@ -3,7 +3,7 @@
 module Google
   module Auth
     module Extras
-      VERSION = '0.5.0'
+      VERSION = '0.6.0'
     end
   end
 end

--- a/spec/google/auth/extras/impersonated_credential_spec.rb
+++ b/spec/google/auth/extras/impersonated_credential_spec.rb
@@ -39,6 +39,25 @@ RSpec.describe Google::Auth::Extras::ImpersonatedCredential do
       expect(credential.scope).to eq(%w[a b c])
     end
 
+    it 'defaults the universe domain to googleapis.com' do
+      credential = described_class.new(
+        email_address: email_address,
+        scope: scopes,
+      )
+
+      expect(credential.universe_domain).to eq('googleapis.com')
+    end
+
+    it 'allows overriding the universe domain' do
+      credential = described_class.new(
+        email_address: email_address,
+        scope: scopes,
+        universe_domain: 'example.com',
+      )
+
+      expect(credential.universe_domain).to eq('example.com')
+    end
+
     it 'requires scope or target_audience' do
       expect do
         described_class.new(

--- a/spec/google/auth/extras/service_account_jwt_credential.rb_spec.rb
+++ b/spec/google/auth/extras/service_account_jwt_credential.rb_spec.rb
@@ -18,6 +18,25 @@ RSpec.describe Google::Auth::Extras::ServiceAccountJWTCredential do
 
       expect(credential.target_audience).to eq(audience)
     end
+
+    it 'defaults the universe domain to googleapis.com' do
+      credential = described_class.new(
+        email_address: email_address,
+        target_audience: audience,
+      )
+
+      expect(credential.universe_domain).to eq('googleapis.com')
+    end
+
+    it 'allows overriding the universe domain' do
+      credential = described_class.new(
+        email_address: email_address,
+        target_audience: audience,
+        universe_domain: 'example.com',
+      )
+
+      expect(credential.universe_domain).to eq('example.com')
+    end
   end
 
   describe '#inspect' do

--- a/spec/google/auth/extras/static_credential_spec.rb
+++ b/spec/google/auth/extras/static_credential_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe Google::Auth::Extras::StaticCredential do
       expect(info_stub).to have_been_requested
     end
 
+    it 'defaults the universe domain to googleapis.com' do
+      TokenInfoStubs.stub_lookup_success(access_token: access_token, expires_in: 290)
+
+      expect(subject.universe_domain).to eq('googleapis.com')
+    end
+
+    context 'when given a universe domain' do
+      subject { described_class.new(access_token: access_token, universe_domain: 'example.com') }
+
+      it 'sets the universe domain' do
+        TokenInfoStubs.stub_lookup_success(access_token: access_token, expires_in: 290)
+
+        expect(subject.universe_domain).to eq('example.com')
+      end
+    end
+
     context 'when given a quota project' do
       subject { described_class.new(access_token: access_token, quota_project_id: 'other-project') }
 

--- a/spec/google/auth/extras_spec.rb
+++ b/spec/google/auth/extras_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe Google::Auth::Extras do
         expect(subject.access_token).to be_nil
         expect(subject.id_token).to be_nil
         expect(subject.token_type).to eq(:access_token)
+        expect(subject.universe_domain).to eq('googleapis.com')
       end
 
       it 'triggers a warning from the GCP SDK' do
@@ -112,6 +113,24 @@ RSpec.describe Google::Auth::Extras do
           expect(subject.id_token).to be_nil
           expect(subject.quota_project_id).to eq('other-project')
           expect(subject.token_type).to eq(:access_token)
+        end
+      end
+
+      context 'with a universe domain' do
+        subject do
+          described_class.impersonated_authorization(
+            base_credentials: base_credentials,
+            delegate_email_addresses: delegate_email_addresses,
+            email_address: email_address,
+            lifetime: lifetime,
+            scope: scopes,
+            universe_domain: 'example.com',
+          )
+        end
+
+        it 'creates the authorization' do
+          expect(subject).to be_a(Google::Auth::Extras::ImpersonatedCredential)
+          expect(subject.universe_domain).to eq('example.com')
         end
       end
     end
@@ -187,6 +206,8 @@ RSpec.describe Google::Auth::Extras do
         expect(subject.client.access_token).to be_nil
         expect(subject.client.id_token).to be_nil
         expect(subject.client.token_type).to eq(:access_token)
+        expect(subject.universe_domain).to eq('googleapis.com')
+        expect(subject.client.universe_domain).to eq('googleapis.com')
       end
 
       it 'does not trigger a warning from the GCP SDK' do
@@ -216,6 +237,25 @@ RSpec.describe Google::Auth::Extras do
           expect(subject.client.id_token).to be_nil
           expect(subject.client.quota_project_id).to eq('other-project')
           expect(subject.client.token_type).to eq(:access_token)
+        end
+      end
+
+      context 'with a universe domain' do
+        subject do
+          described_class.impersonated_credential(
+            base_credentials: base_credentials,
+            delegate_email_addresses: delegate_email_addresses,
+            email_address: email_address,
+            lifetime: lifetime,
+            scope: scopes,
+            universe_domain: 'example.com',
+          )
+        end
+
+        it 'creates the credential' do
+          expect(subject).to be_a(Google::Auth::Credentials)
+          expect(subject.universe_domain).to eq('example.com')
+          expect(subject.client.universe_domain).to eq('example.com')
         end
       end
     end
@@ -290,6 +330,7 @@ RSpec.describe Google::Auth::Extras do
       expect(subject.access_token).to be_nil
       expect(subject.id_token).to be_nil
       expect(subject.token_type).to eq(:id_token)
+      expect(subject.universe_domain).to eq('googleapis.com')
     end
 
     it 'triggers a warning from the GCP SDK' do
@@ -299,6 +340,23 @@ RSpec.describe Google::Auth::Extras do
 
       expect(Kernel).to have_received(:warn)
         .with(/Invalid value #<Google::Auth::Extras::ServiceAccountJWTCredential .* for key :credentials\. Setting anyway\./)
+    end
+
+    context 'with a universe domain' do
+      subject do
+        described_class.service_account_jwt_authorization(
+          base_credentials: base_credentials,
+          delegate_email_addresses: delegate_email_addresses,
+          email_address: email_address,
+          target_audience: audience,
+          universe_domain: 'example.com',
+        )
+      end
+
+      it 'creates the authorization' do
+        expect(subject).to be_a(Google::Auth::Extras::ServiceAccountJWTCredential)
+        expect(subject.universe_domain).to eq('example.com')
+      end
     end
   end
 
@@ -320,6 +378,8 @@ RSpec.describe Google::Auth::Extras do
       expect(subject.client.access_token).to be_nil
       expect(subject.client.id_token).to be_nil
       expect(subject.client.token_type).to eq(:id_token)
+      expect(subject.universe_domain).to eq('googleapis.com')
+      expect(subject.client.universe_domain).to eq('googleapis.com')
     end
 
     it 'does not trigger a warning from the GCP SDK' do
@@ -328,6 +388,24 @@ RSpec.describe Google::Auth::Extras do
       Google::Cloud.configure.storage.credentials = subject
 
       expect(Kernel).not_to have_received(:warn)
+    end
+
+    context 'with a universe domain' do
+      subject do
+        described_class.service_account_jwt_credential(
+          base_credentials: base_credentials,
+          delegate_email_addresses: delegate_email_addresses,
+          email_address: email_address,
+          target_audience: audience,
+          universe_domain: 'example.com',
+        )
+      end
+
+      it 'creates the credential' do
+        expect(subject).to be_a(Google::Auth::Credentials)
+        expect(subject.universe_domain).to eq('example.com')
+        expect(subject.client.universe_domain).to eq('example.com')
+      end
     end
   end
 
@@ -339,6 +417,7 @@ RSpec.describe Google::Auth::Extras do
     it 'creates the authorization' do
       expect(subject).to be_a(Google::Auth::Extras::StaticCredential)
       expect(subject.access_token).to eq(access_token)
+      expect(subject.universe_domain).to eq('googleapis.com')
 
       expect(info_stub).to have_been_requested
     end
@@ -362,6 +441,17 @@ RSpec.describe Google::Auth::Extras do
         expect(info_stub).to have_been_requested
       end
     end
+
+    context 'with a universe domain' do
+      subject { described_class.static_authorization(access_token, universe_domain: 'example.com') }
+
+      it 'creates the authorization' do
+        expect(subject).to be_a(Google::Auth::Extras::StaticCredential)
+        expect(subject.universe_domain).to eq('example.com')
+
+        expect(info_stub).to have_been_requested
+      end
+    end
   end
 
   describe '.static_credential' do
@@ -373,6 +463,8 @@ RSpec.describe Google::Auth::Extras do
       expect(subject).to be_a(Google::Auth::Credentials)
       expect(subject.client).to be_a(Google::Auth::Extras::StaticCredential)
       expect(subject.client.access_token).to eq(access_token)
+      expect(subject.universe_domain).to eq('googleapis.com')
+      expect(subject.client.universe_domain).to eq('googleapis.com')
 
       expect(info_stub).to have_been_requested
     end
@@ -396,6 +488,38 @@ RSpec.describe Google::Auth::Extras do
 
         expect(info_stub).to have_been_requested
       end
+    end
+
+    context 'with a universe domain' do
+      subject { described_class.static_credential(access_token, universe_domain: 'example.com') }
+
+      it 'creates the credential' do
+        expect(subject).to be_a(Google::Auth::Credentials)
+        expect(subject.universe_domain).to eq('example.com')
+        expect(subject.client.universe_domain).to eq('example.com')
+
+        expect(info_stub).to have_been_requested
+      end
+    end
+  end
+
+  describe '.wrap_authorization' do
+    let(:client) { Signet::OAuth2::Client.new }
+
+    it 'wraps the client in a Google::Auth::Credentials' do
+      credential = described_class.wrap_authorization(client)
+
+      expect(credential).to be_a(Google::Auth::Credentials)
+      expect(credential.client).to be(client)
+    end
+
+    it 'delegates to the universe domain already set on the client' do
+      client.universe_domain = 'example.com'
+
+      credential = described_class.wrap_authorization(client)
+
+      expect(credential.universe_domain).to eq('example.com')
+      expect(credential.client.universe_domain).to eq('example.com')
     end
   end
 end


### PR DESCRIPTION
this fixes a regression with more recent v3 versions of the google sdk gems using gapic-common under the hood, which enforces matching of the credentials universe domain with the client universe domain.

**Potential Risk**

Worst Case Incident: SEV-4